### PR TITLE
Added Rocket Jumper effect, fixed issue with potion effect durations

### DIFF
--- a/src/main/java/eu/teamtime/chaospie/ChaosPie.java
+++ b/src/main/java/eu/teamtime/chaospie/ChaosPie.java
@@ -55,15 +55,16 @@ public class ChaosPie {
 		instance = this;
 
 		// TODO Make sure all effects are in
+		effects.add(new CakeCreeperEffect());
+		effects.add(new FishingNightmareEffect());
 		effects.add(new FloatingEffect());
 		effects.add(new HeliumPunchEffect());
 		effects.add(new HostileDuplicateEffect());
 		effects.add(new MiniCookEffect());
 		effects.add(new NascarEffect());
+		effects.add(new RocketJumperEffect());
 		effects.add(new SpeedySpidersEffect());
 		effects.add(new SolarFlareEffect());
-		effects.add(new CakeCreeperEffect());
-		effects.add(new FishingNightmareEffect());
 		
 		metrics = new EffectMetrics();
 		registerCommands();

--- a/src/main/java/eu/teamtime/chaospie/ChaosPie.java
+++ b/src/main/java/eu/teamtime/chaospie/ChaosPie.java
@@ -31,6 +31,8 @@ import eu.teamtime.chaospie.effects.*;
 @Plugin(id = "chaospie", name = "ChaosPie", version = "0.1")
 public class ChaosPie {
 	
+	public static final int TIME_BETWEEN_EFFECTS = 120;
+	
 	private static ChaosPie instance;
 	public static ChaosPie instance() {
 		return instance;
@@ -72,7 +74,7 @@ public class ChaosPie {
 		schedule = Task.builder()
 				.execute(this::startRandomChaosEvent)
 				.delay(10, TimeUnit.SECONDS)
-				.interval(2, TimeUnit.MINUTES)
+				.interval(TIME_BETWEEN_EFFECTS, TimeUnit.SECONDS)
 				.name("ChaosPie-ChaosEffectScheduler")
 				.submit(this);
 	}

--- a/src/main/java/eu/teamtime/chaospie/ChaosPotionBase.java
+++ b/src/main/java/eu/teamtime/chaospie/ChaosPotionBase.java
@@ -46,6 +46,11 @@ public abstract class ChaosPotionBase extends ChaosEffectBase {
 			}
 		}
 	}
+	
+	public final int safeLengthInSeconds() {
+		int time = lengthInSeconds();
+		return (time <= 0 ? 120 : time);
+	}
 
 	protected abstract Text getStartText();
 

--- a/src/main/java/eu/teamtime/chaospie/ChaosPotionBase.java
+++ b/src/main/java/eu/teamtime/chaospie/ChaosPotionBase.java
@@ -49,7 +49,7 @@ public abstract class ChaosPotionBase extends ChaosEffectBase {
 	
 	public final int safeLengthInSeconds() {
 		int time = lengthInSeconds();
-		return (time <= 0 ? 120 : time);
+		return (time <= 0 ? ChaosPie.TIME_BETWEEN_EFFECTS : time);
 	}
 
 	protected abstract Text getStartText();

--- a/src/main/java/eu/teamtime/chaospie/effects/FloatingEffect.java
+++ b/src/main/java/eu/teamtime/chaospie/effects/FloatingEffect.java
@@ -22,7 +22,7 @@ import eu.teamtime.chaospie.ChaosPotionBase;
 public class FloatingEffect extends ChaosPotionBase {
 
 	private final Collection<PotionEffect> effects = Arrays.asList(PotionEffect.builder().amplifier(255)
-			.duration(lengthInSeconds()).potionType(PotionEffectTypes.LEVITATION).build());
+			.duration(safeLengthInSeconds()).potionType(PotionEffectTypes.LEVITATION).build());
 
 	@Override
 	public int lengthInSeconds() {

--- a/src/main/java/eu/teamtime/chaospie/effects/NascarEffect.java
+++ b/src/main/java/eu/teamtime/chaospie/effects/NascarEffect.java
@@ -21,9 +21,9 @@ import eu.teamtime.chaospie.ChaosPotionBase;
 public class NascarEffect extends ChaosPotionBase {
 
 	private final Collection<PotionEffect> effects = Arrays.asList(
-			PotionEffect.builder().amplifier(60).duration(lengthInSeconds()).potionType(PotionEffectTypes.SPEED)
+			PotionEffect.builder().amplifier(60).duration(safeLengthInSeconds()).potionType(PotionEffectTypes.SPEED)
 					.build(),
-			PotionEffect.builder().amplifier(250).duration(lengthInSeconds()).potionType(PotionEffectTypes.JUMP_BOOST)
+			PotionEffect.builder().amplifier(250).duration(safeLengthInSeconds()).potionType(PotionEffectTypes.JUMP_BOOST)
 					.build());
 
 	@Override

--- a/src/main/java/eu/teamtime/chaospie/effects/RocketJumperEffect.java
+++ b/src/main/java/eu/teamtime/chaospie/effects/RocketJumperEffect.java
@@ -1,0 +1,99 @@
+package eu.teamtime.chaospie.effects;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.channel.MessageChannel;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.world.explosion.Explosion;
+
+import com.google.common.collect.Lists;
+
+import eu.teamtime.chaospie.ChaosEffectBase;
+import eu.teamtime.chaospie.ChaosPie;
+
+/**
+ * Chaos effect that causes sporadic explosions underneath players,
+ * sending them flying into the air.
+ * 
+ * @author Karanum
+ */
+public class RocketJumperEffect extends ChaosEffectBase {
+
+	private Task task;
+	private Random random;
+	private Explosion.Builder explosionTemplate;
+	private List<Player> cooldownPlayers;
+	
+	public RocketJumperEffect() {
+		random = new Random();
+	}
+	
+	@Override
+	public void start() {
+		MessageChannel.TO_PLAYERS.send(Text.of(TextColors.RED, "Did you hear something? Get your market gardener ready!"));
+		cooldownPlayers = Lists.newArrayList();
+		task = Task.builder()
+				.delay(random.nextInt(1000) + 500, TimeUnit.MILLISECONDS)
+				.execute(() -> doTick())
+				.submit(ChaosPie.instance());
+		
+		explosionTemplate = Explosion.builder()
+				.canCauseFire(false)
+				.shouldDamageEntities(false)
+				.shouldBreakBlocks(false)
+				.shouldPlaySmoke(true)
+				.radius(3);
+	}
+
+	@Override
+	public void stop() {
+		MessageChannel.TO_PLAYERS.send(Text.of(TextColors.GREEN, "The explosions come to a stop. The market is closed for the day."));
+		if (task != null)
+			task.cancel();
+	}
+
+	@Override
+	public int lengthInSeconds() {
+		return 60;
+	}
+
+	@Override
+	public int getWeight() {
+		return 30;
+	}
+
+	@Override
+	public String getName() {
+		return "Rocket Jumper";
+	}
+	
+	private void doTick() {
+		Sponge.getCauseStackManager().pushCause(ChaosPie.instance());
+		List<Player> explodedPlayers = Lists.newArrayList();
+		
+		for (Player p : Sponge.getServer().getOnlinePlayers()) {
+			if (cooldownPlayers.contains(p) || random.nextDouble() < 0.7)
+				continue;
+			
+			explodedPlayers.add(p);
+			Explosion explosion = explosionTemplate.location(p.getLocation()).build();
+			p.getWorld().triggerExplosion(explosion);
+		}
+		
+		Sponge.getCauseStackManager().popCause();
+		cooldownPlayers.clear();
+		cooldownPlayers = explodedPlayers;
+		
+		task = Task.builder()
+				.delay(random.nextInt(1000) + 500, TimeUnit.MILLISECONDS)
+				.execute(() -> doTick())
+				.submit(ChaosPie.instance());
+	}
+
+}

--- a/src/main/java/eu/teamtime/chaospie/effects/SpeedySpidersEffect.java
+++ b/src/main/java/eu/teamtime/chaospie/effects/SpeedySpidersEffect.java
@@ -24,7 +24,7 @@ import eu.teamtime.chaospie.ChaosPotionBase;
 public class SpeedySpidersEffect extends ChaosPotionBase {
 
 	private final Collection<PotionEffect> effects = Arrays.asList(PotionEffect.builder().amplifier(40)
-			.duration(lengthInSeconds()).potionType(PotionEffectTypes.SPEED).build());
+			.duration(safeLengthInSeconds()).potionType(PotionEffectTypes.SPEED).build());
 
 	@Override
 	public int lengthInSeconds() {


### PR DESCRIPTION
Potion-based chaos effects made use of the `lengthInSeconds` method to determine the length of the potion effect. With full length effects being set to 0 seconds, this broke the potion effects. Added a new `safeLengthInSeconds` method to the ChaosPotionBase class that returns the length in seconds, or the full length of a chaos effect if the length is 0.